### PR TITLE
chore: cope with double git headers

### DIFF
--- a/apps/backend/src/utils/git-parser.ts
+++ b/apps/backend/src/utils/git-parser.ts
@@ -96,7 +96,7 @@ export async function parseGitLog(
         callback({ header, body });
         body = [];
         state = 'header';
-      } else if (!line.includes('\t')) {
+      } else if (line.split('\t').length < 3) {
         header = parseHeader(line);
       } else {
         const bodyEntry = parseBodyEntry(line, renameMap);


### PR DESCRIPTION
- chore: check git log line for at least two tabs before treating as file line

Note: double headers seem to occur when merge commits are not squashed