### PR TITLE
feat: support git log aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ npm i @softarc/detective -D
 npx detective
 ```
 
+## Defining aliases
+
+In case users have used multiple names, as appearing in the `git log`, use the `aliases` option in the file `.detective/config.json` created the first time detective runs:
+
+```json
+{
+  [...]
+  "aliases": {
+    "jdoe": "John Doe", 
+    "janedoe": "Jane Doe"
+  }
+  [...]
+}
+```
+
 ## Defining Teams
 
 For the Team Alignment Analysis, you need to map team names to the names of your team members as found in `git log`. This is done in the file `.detective/config.json` created the first time detective runs:

--- a/apps/backend/src/infrastructure/config.ts
+++ b/apps/backend/src/infrastructure/config.ts
@@ -13,6 +13,7 @@ const initConfig: Config = {
     files: [],
     logs: [],
   },
+  aliases: {},
   teams: {
     'example-team-a': ['John Doe', 'Jane Doe'],
     'example-team-b': ['Max Muster', 'Susi Sorglos'],

--- a/apps/backend/src/model/config.ts
+++ b/apps/backend/src/model/config.ts
@@ -8,6 +8,7 @@ export type Config = {
   groups: string[];
   filter: Filter;
   teams: Record<string, string[]>;
+  aliases: Record<string, string>;
   entries: [];
 };
 
@@ -15,6 +16,7 @@ export const emptyConfig: Config = {
   scopes: [],
   groups: [],
   teams: {},
+  aliases: {},
   entries: [],
   filter: {
     logs: [],

--- a/apps/backend/src/services/team-alignment.ts
+++ b/apps/backend/src/services/team-alignment.ts
@@ -50,6 +50,8 @@ export async function calcTeamAlignment(
       }
     }
 
+    userName = config.aliases?.[userName] || userName;
+
     users.add(userName);
 
     const key = calcKey(byUser, userName, userToTeam);

--- a/apps/backend/src/utils/git-parser.ts
+++ b/apps/backend/src/utils/git-parser.ts
@@ -96,7 +96,7 @@ export async function parseGitLog(
         callback({ header, body });
         body = [];
         state = 'header';
-      } else if (!line.includes('\t')) {
+      } else if (line.split('\t').length < 3) {
         header = parseHeader(line);
       } else {
         const bodyEntry = parseBodyEntry(line, renameMap);


### PR DESCRIPTION
With this addition. it is possible to map alternate names as used in the git infrastructure, using aliases from the config.