### PR TITLE
feat: show actual teams/users in team alignment

### DIFF
--- a/apps/backend/src/services/team-alignment.spec.ts
+++ b/apps/backend/src/services/team-alignment.spec.ts
@@ -114,10 +114,10 @@ describe('team alignment service', () => {
     });
 
     expect(result.teams).toEqual([
-      'John Doe',
       'Jane Doe',
-      'Max Muster',
+      'John Doe',
       'Maria Muster',
+      'Max Muster',
     ]);
   });
 

--- a/apps/backend/src/services/team-alignment.ts
+++ b/apps/backend/src/services/team-alignment.ts
@@ -28,7 +28,7 @@ export async function calcTeamAlignment(
   const userToTeam = initUserToTeam(teams);
   const result = initResult(displayModules, Object.keys(teams));
 
-  const users = new Set<string>();
+  const actualTeams = new Set<string>();
 
   const parseOptions: ParseOptions = {
     limits,
@@ -52,9 +52,8 @@ export async function calcTeamAlignment(
 
     userName = config.aliases?.[userName] || userName;
 
-    users.add(userName);
-
     const key = calcKey(byUser, userName, userToTeam);
+    actualTeams.add(key);
 
     for (const change of entry.body) {
       for (let i = 0; i < modules.length; i++) {
@@ -72,9 +71,7 @@ export async function calcTeamAlignment(
     }
   }, parseOptions);
 
-  if (byUser) {
-    result.teams = Array.from(users);
-  }
+  result.teams = Array.from(actualTeams).sort();
 
   return result;
 }


### PR DESCRIPTION
It struck me as odd that I saw a team "unknown", whereas the users were all collected in appropriate teams, also I saw teams that did not contribute to the selected branch in the tree; this PR fixes that, by always returning the actual teams that are resulting from a team alignment analysis. The team/user names are sorted alfabetically to have a more or less predictable outcome, and by chance separate the most active users somewhat, making the colored donut charts slightly easier to analyse.

###  BEFORE:
When 'By user' is not selected, all teams are shown, including a artificial team 'unknown', even when a team or 'unknown' was actually not part of the analysis.

###  AFTER:
Only teams that occur in the analysis are shown.


## Checklist for PR

- [x] PR is only about one and only one concern
- [x] Description contains a short title, an optional description, and the sections BEFORE and AFTER
- [x] (A) new short test(s) show(s) that the PR is working (shown in adapted existing test)
