### PR TITLE
fix: correct separators in git log rename handling

### DIFF
--- a/apps/backend/src/services/folders.ts
+++ b/apps/backend/src/services/folders.ts
@@ -50,6 +50,11 @@ export function inferFolders(options: Options): Folder[] {
     }
   }
 
-  const converted = toFolder(root);
+  let converted = toFolder(root);
+  while (
+    converted.folders.length === 1 &&
+    converted.folders[0].folders.length === 1
+  )
+    converted = converted.folders[0];
   return converted.folders;
 }

--- a/apps/backend/src/utils/git-parser.spec.ts
+++ b/apps/backend/src/utils/git-parser.spec.ts
@@ -74,6 +74,7 @@ const logWithRenames = `"John Doe <john.doe@acme.com>,${today.toISOString()}"
 "Jane Doe <john.doe@acme.com>,${today.toISOString()}"
 10\t0\t/shell/my.component.ts
 0\t1\t/shell/my-other.component.ts
+20\t1\t/shared/feature-checkin/my.component.ts
 `;
 
 jest.mock('../infrastructure/log');
@@ -505,6 +506,11 @@ describe('git parser', () => {
               linesAdded: 0,
               linesRemoved: 1,
               path: '/shell/my-other.component.ts',
+            },
+            {
+              linesAdded: 20,
+              linesRemoved: 1,
+              path: '/shared/sub-features/feature-checkin/my.component.ts',
             },
           ],
         },

--- a/apps/backend/src/utils/git-parser.ts
+++ b/apps/backend/src/utils/git-parser.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import microMatch from 'micromatch';
 
 import { loadCachedLog } from '../infrastructure/log';

--- a/apps/backend/src/utils/git-parser.ts
+++ b/apps/backend/src/utils/git-parser.ts
@@ -148,7 +148,10 @@ function parseBodyEntry(
 
 // path.join replacement that does not depend on OS, and normalizes separators as used in a git log
 function pathJoin(...args: string[]) {
-  return args.join('/').replace(/\/{2,}/g, '/').replace(/\/$/g, '');
+  return args
+    .join('/')
+    .replace(/\/{2,}/g, '/')
+    .replace(/\/$/g, '');
 }
 
 function handleRenames(filePath: string, renameMap: Map<string, string>) {

--- a/apps/backend/src/utils/git-parser.ts
+++ b/apps/backend/src/utils/git-parser.ts
@@ -148,6 +148,11 @@ function parseBodyEntry(
   return bodyEntry;
 }
 
+// path.join replacement that does not depend on OS, and normalizes separators as used in a git log
+function pathJoin(...args) {
+  return args.join('/').replace(/\/{2,}/g, '/').replace(/\/$/g, '');
+}
+
 function handleRenames(filePath: string, renameMap: Map<string, string>) {
   const result = filePath.match(/(.*?)\{(.*?) => (.*?)\}(.*)/);
 
@@ -157,8 +162,8 @@ function handleRenames(filePath: string, renameMap: Map<string, string>) {
     const after = result[3];
     const end = result[4];
 
-    const from = path.join(start, before, end);
-    const to = path.join(start, after, end);
+    const from = pathJoin(start, before, end);
+    const to = pathJoin(start, after, end);
 
     renameMap.set(from, renameMap.get(to) || to);
     filePath = to;

--- a/apps/backend/src/utils/git-parser.ts
+++ b/apps/backend/src/utils/git-parser.ts
@@ -149,7 +149,7 @@ function parseBodyEntry(
 }
 
 // path.join replacement that does not depend on OS, and normalizes separators as used in a git log
-function pathJoin(...args) {
+function pathJoin(...args: string[]) {
   return args.join('/').replace(/\/{2,}/g, '/').replace(/\/$/g, '');
 }
 


### PR DESCRIPTION
Solve issues with separators in git log rename handling

Solves https://github.com/angular-architects/detective/issues/26

### BEFORE
Portrays issue 26

### AFTER
Correctly deals with separators in git log rename handling

## Checklist for PR

- [x] PR is only about one and only one concern
- [x] Description contains a short title, an optional description, and the sections BEFORE and AFTER
- [x] (A) new short test(s) show(s) that the PR is working; extended existing test-data to show this

