### PR TITLE
fix: change repo detection to search also in upper paths

### DIFF
--- a/apps/backend/src/infrastructure/git.ts
+++ b/apps/backend/src/infrastructure/git.ts
@@ -1,10 +1,14 @@
-import { spawn, spawnSync } from 'child_process';
-import * as fs from 'fs';
+import { execSync, spawn, spawnSync } from 'child_process';
 
 import { noLimits } from '../model/limits';
 
 export function isRepo(): boolean {
-  return fs.existsSync('.git');
+  try {
+    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    return false;
+  }
 }
 
 export function calcTreeHash(): string {


### PR DESCRIPTION
## Checklist for PR

- [ ] PR is only about one and only one concern
- [ ] Description contains a short title, an optional description, and the sections BEFORE and AFTER
- [ ] (A) new short test(s) show(s) that the PR is working

## Some more infos

- Short PR: adding two features and formatting code in other features is too much

- BEFARE and AFTER sections:

  ```
  BEFORE:
   The .git folder was expected to be in the same folder like the nx project

  AFTER:
    The .git folder is detected by using git rev-parse till the root folder of the repositiory is found.

  ```
