### PR TITLE
fix: normalize usernames with NFC to dedupe umlaut variants

### DIFF
--- a/apps/backend/src/services/team-alignment.ts
+++ b/apps/backend/src/services/team-alignment.ts
@@ -50,7 +50,7 @@ export async function calcTeamAlignment(
       }
     }
 
-    userName = config.aliases?.[userName] || userName;
+    userName = (config.aliases?.[userName] || userName).normalize('NFC');
 
     const key = calcKey(byUser, userName, userToTeam);
     actualTeams.add(key);


### PR DESCRIPTION
## Checklist for PR

- [X] PR is only about one and only one concern
- [X] Description contains a short title, an optional description, and the sections BEFORE and AFTER
- [X] (A) new short test(s) show(s) that the PR is working

## Some more infos

In `calcTeamAlignment`, the actualTeams set can end up containing "duplicate" entries for the same user when their name includes an umlaut. This happens because JavaScript strings with precomposed (“ä” U+00E4) and decomposed (“a\u0308” + COMBINING DIAERESIS) representations are treated as distinct values by Set. We need to normalize all usernames to NFC before using them as keys so that “Mäster” and “Mäster”  collapse to the same string.

BEFORE:
      You will end up with two users in the set

AFTER:
       Only one user. Test in `team-alignment.spec.ts`should clearify

