### PR TITLE
fix: adjust distance limits for city 3D component interaction

### DIFF
--- a/.detective/config.json
+++ b/.detective/config.json
@@ -1,14 +1,6 @@
 {
-  "scopes": [
-    "apps/backend/src/infrastructure",
-    "apps/backend/src/mcp",
-    "apps/backend/src/model",
-    "apps/backend/src/options",
-    "apps/backend/src/services",
-    "apps/backend/src/utils",
-    "apps/frontend"
-  ],
-  "groups": ["apps/backend/src", "apps/backend", "apps"],
+  "scopes": ["apps"],
+  "groups": [],
   "entries": [],
   "filter": {
     "files": [],

--- a/apps/backend/src/services/team-alignment.ts
+++ b/apps/backend/src/services/team-alignment.ts
@@ -42,19 +42,18 @@ export async function calcTeamAlignment(
 
     if (options.demoMode) {
       count++;
-      if (count % 4 === 1) {
-        userName = 'Max Muster';
-      } else if (count % 4 === 2) {
-        userName = 'John Doe';
-      } else if (count % 4 == 3) {
-        userName = 'Jane Doe';
-      }
+      const demoUsers = ['Max Muster', 'John Doe', 'Jane Doe', 'Maria Muster'];
+      userName = demoUsers[(count - 1) % demoUsers.length];
     }
 
     userName = config.aliases?.[userName] || userName;
 
     const emailLower = (entry.header.email || '').toLowerCase();
-    const stableUserKey = byUser ? emailLower || userName : userName;
+    const stableUserKey = byUser
+      ? options.demoMode
+        ? userName
+        : emailLower || userName
+      : userName;
 
     if (!userKeyToDisplay[stableUserKey]) {
       userKeyToDisplay[stableUserKey] = userName;

--- a/apps/frontend/src/app/features/hotspot-city/city3d.component.ts
+++ b/apps/frontend/src/app/features/hotspot-city/city3d.component.ts
@@ -86,7 +86,7 @@ export class City3DComponent implements OnChanges, OnDestroy {
   private targetRotationY = 0;
   private targetPanX = 0;
   private targetPanZ = 0;
-  private distance = 100;
+  private distance = 20;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['items'] || changes['mode']) {
@@ -443,7 +443,7 @@ export class City3DComponent implements OnChanges, OnDestroy {
     if (!this.renderer || !target || !this.renderer.domElement.contains(target))
       return;
     this.distance += event.deltaY * 0.05;
-    this.distance = Math.max(20, Math.min(4000, this.distance));
+    this.distance = Math.max(0, this.distance);
     event.preventDefault();
   }
 


### PR DESCRIPTION
Adjust City3D zoom to allow unlimited zoom with a floor at 0 and set initial distance to 20.
Fix demo user assignment logic in calcTeamAlignment function

## BEFORE:
Zoom distance was clamped between 20 and 4000.
Initial camera distance was 100.
Demo users were not displayed because the did not had emails.

## AFTER:
Zoom has no upper limit; minimum distance clamped at 0.
Initial camera distance set to 20.
Camera fit respects the 0 floor.
Demo users are shown as expected

## Checklist for PR
- [] PR is only about one and only one concern
- [x] Description contains a short title, an optional description, and the sections BEFORE and AFTER
- [ ] (A) new short test(s) show(s) that the PR is working